### PR TITLE
SC-460: Redirect http to https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+gem 'rack-rewrite', '~> 1.5.0'
 
 ruby '2.3.1'
 gem 'slack-api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     multi_json (1.12.1)
     multipart-post (2.0.0)
     rack (1.6.4)
+    rack-rewrite (1.5.1)
     rake (11.1.2)
     slack-api (1.2.3)
       faraday (>= 0.7, < 0.10)
@@ -29,6 +30,7 @@ PLATFORMS
 DEPENDENCIES
   dotenv
   rack
+  rack-rewrite (~> 1.5.0)
   rake
   slack-api
 

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,9 @@
 require './bin/fetch-gems'
+require 'rack/rewrite'
+
+use Rack::Rewrite do
+  r301 %r{.*}, 'https://localhost:9292', :scheme => 'http'
+end
 
 use Rack::Static,
   :urls => ["/images", "/js", "/css", "/data"],


### PR DESCRIPTION
## Description
Redirect http://gems.seesparkbox.com to https://gems.seesparkbox.com/
In order to get on the Chrome HSTS preload list, our subdomains need to have HTTPS and redirect HTTP to HTTPS. 

## To Test
1. Make sure all PR Checks have passed (CircleCI, Code Climate, Snyk, etc).
1. Pull down this branch.
1. Confirm all tests pass: `npm run test` & `npm run test:a11y`
1. Navigate to http://localhost:9292 and confirm that is redirects to https://localhost:9292

Once this checks out, I will update the redirect on this line to 
```use Rack::Rewrite do
  r301 %r{.*}, 'https://gems.seesparkbox.com/', :scheme => 'http'
end```
