### PR TITLE
fix: correct gems url for redirect

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,7 +2,7 @@ require './bin/fetch-gems'
 require 'rack/rewrite'
 
 use Rack::Rewrite do
-  r301 %r{.*}, 'https://localhost:9292', :scheme => 'http'
+  r301 %r{.*}, 'https://gems.seesparkbox.com/', :scheme => 'http'
 end
 
 use Rack::Static,


### PR DESCRIPTION
**Description**

Updating url to the correct https://gems.seesparkbox.com/ path