### PR TITLE
Fix: Issue retrieving Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gem 'rack-rewrite', '~> 1.5.0'
 
 ruby '2.7.2'
 
-gem 'slack-api'
 gem 'dotenv'
 gem 'rack'
 gem 'rake'
+gem 'slack-ruby-client'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 gem 'rack-rewrite', '~> 1.5.0'
 
-ruby '2.3.1'
+ruby '2.7.2'
+
 gem 'slack-api'
 gem 'dotenv'
 gem 'rack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ DEPENDENCIES
   slack-api
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,40 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.1.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    concurrent-ruby (1.1.8)
     dotenv (2.1.1)
-    eventmachine (1.2.0.1)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
-    faye-websocket (0.9.2)
-      eventmachine (>= 0.12.0)
-      websocket-driver (>= 0.5.1)
-    multi_json (1.12.1)
+    gli (2.20.0)
+    hashie (4.1.0)
+    i18n (1.8.9)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.4)
     multipart-post (2.0.0)
     rack (1.6.4)
     rack-rewrite (1.5.1)
     rake (11.1.2)
-    slack-api (1.2.3)
-      faraday (>= 0.7, < 0.10)
-      faraday_middleware (~> 0.8)
-      faye-websocket (~> 0.9.2)
-      multi_json (~> 1.0, >= 1.0.3)
+    slack-ruby-client (0.14.6)
+      activesupport
+      faraday (>= 0.9)
+      faraday_middleware
+      gli
+      hashie
+      websocket-driver
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -32,10 +44,10 @@ DEPENDENCIES
   rack
   rack-rewrite (~> 1.5.0)
   rake
-  slack-api
+  slack-ruby-client
 
 RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.0.1
+   2.2.14

--- a/bin/fetch-gems.rb
+++ b/bin/fetch-gems.rb
@@ -6,7 +6,11 @@ require "fileutils"
 Dotenv.load
 
 token = ENV["TOKEN"] || (print "Token: "; gets.strip)
-$client = Slack::Client.new token: token
+Slack.configure do |config|
+  config.token = token
+end
+
+$client = Slack::Web::Client.new token: token
 
 # Get users list
 puts 'fetching latest data...'
@@ -22,7 +26,7 @@ class Client
   end
 
   def history
-    slack.channels_history channel: GEMS_CHANNEL_ID, count: 1000, latest: timestamp, inclusive: true
+    slack.conversations_history channel: GEMS_CHANNEL_ID, count: 1000, latest: timestamp, inclusive: true
   end
 
   def messages
@@ -42,7 +46,7 @@ class Client
   private
 
   def slack
-    @slack ||= Slack::Client.new(token: ENV["TOKEN"])
+    @slack ||= Slack::Web::Client.new(token: ENV["TOKEN"])
   end
 end
 


### PR DESCRIPTION
## Summary
This PR fixes an issue retrieving gems on Heroku. Specifically, it updates our fetcher to use the `conversations.history` API instead of the `channels.history` API.

### Validation
1. Pull down this branch.
1. Run `bundle install`
1. Run `bundle exec rake`.
- [ ] Confirm a .json file of gems is available at `public/data`.